### PR TITLE
Adding support for kubernetes configmaps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,9 @@ RUN apt-get update -qqy \
        wget unzip ca-certificates \
     && rm -fr /var/lib/apt/lists/*
 
+
+RUN mkdir -p /etc/grok_exporter
+RUN ln -sf /etc/grok_exporter/config.yml /grok/
 WORKDIR /grok
 
-CMD ["./grok_exporter", "-config", "/grok/config.yml"]   
+CMD ["./grok_exporter", "-config", "/grok/config.yml"]

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ Export [Prometheus] metrics from arbitrary unstructured log data.
 
 ## About Grok
 
-[Grok] is a tool to parse crappy unstructured log data into something structured and queryable. 
+[Grok] is a tool to parse crappy unstructured log data into something structured and queryable.
 
-The [`grok_exporter`] aims at porting Grok from the ELK stack to [Prometheus] monitoring. The goal is to use Grok patterns for extracting Prometheus metrics from arbitrary log files. 
+The [`grok_exporter`] aims at porting Grok from the ELK stack to [Prometheus] monitoring. The goal is to use Grok patterns for extracting Prometheus metrics from arbitrary log files.
 
 ## How to use this image
 
@@ -15,14 +15,14 @@ You need to provide [`grok_exporter`] with a config file in order to function pr
 There are various ways in which you can utilize this image, each however assumes that the log file you're trying to parse is reacheable by the grok_exporter container.
 
 
-### Running Solo 
+### Running Solo
 
 This assumes Prometheus is installed locally (or on another server) and therefore, the metrics endpoint that `grok_exporter` exposes must be reachable:
 
 ```sh
 docker container run --name grok -d \
                      -p PORT:PORT \
-                     -v $(pwd)/config.yml:/grok/config.yml \
+                     -v $(pwd)/config.yml:/etc/grok_exporter/config.yml \
                      palobo/grok_exporter
 ```
 
@@ -36,7 +36,7 @@ Assuming you're using this image alonside other images (Prometheus and Grafana r
 ```sh
 docker container run --name grok -d \
                      --net PROM-NETWORK \
-                     -v $(pwd)/config.yml:/grok/config.yml \
+                     -v $(pwd)/config.yml:/etc/grok_exporter/config.yml \
                      palobo/grok_exporter
 ```
 


### PR DESCRIPTION
When mounting configmaps in k8s original data in directory is not accessible. When file is mounted in different directory and then linked there is no problem.